### PR TITLE
Added People's Choice Product API endpoints

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -3,5 +3,6 @@
     {"name": "CBA", "url": "https://api.commbank.com.au/public/cds-au/v1"},
     {"name": "NAB", "url": "https://openbank.api.nab.com.au/cds-au/v1"},
     {"name": "Westpac", "url": "https://digital-api.westpac.com.au/cds-au/v1"},
-    {"name": "Suncorp", "url": "https://api-pub-cdr.suncorpbank.com.au/cds-au/v1", "icon": "https://suncorp.com.au/content/dam/suncorp/corporate/images/logos/Suncorp_New_Logo.png"}
+    {"name": "Suncorp", "url": "https://api-pub-cdr.suncorpbank.com.au/cds-au/v1", "icon": "https://suncorp.com.au/content/dam/suncorp/corporate/images/logos/Suncorp_New_Logo.png"},
+    {"name": "People's Choice", "url": "https://api.peopleschoice.com.au/public/cds-au/v1"}
 ]


### PR DESCRIPTION
People's Choice Credit Union Get Products and Get Product Details API endpoints are now available to the public. This change is to include the endpoint in the banking-products-comparator tool.