### PR TITLE
Added Beyond Bank data source

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -15,6 +15,7 @@
     {"name": "bcu", "url": "https://ob-api.bcu.com.au/cds-au/v1", "icon": "https://www.bcu.com.au/content-publishers/logo/BCU_Logo_CMYK_200px.png"},
     {"name": "BDCU Alliance Bank", "url": "https://api.cdr.bdcualliancebank.com.au/cds-au/v1"},
     {"name": "Bendigo Bank", "url": "https://api.cdr.bendigobank.com.au/cds-au/v1"},
+    {"name": "Beyond Bank", "url": "https://public.cdr.api.beyondbank.com.au/cds-au/v1"},
     {"name": "BOQ", "url": "https://secure.api.boq.com.au/cds-au/v1", "icon": "https://www.boq.com.au/content/dam/boq/images/blog-images/BOQ_png_notagline_stk.png"},
     {"name": "BOQ Specialist", "url": "https://secure.api.boqspecialist.com.au/cds-au/v1", "icon": "https://www.boqspecialist.com.au/content/dam/boqs/images/logo.png"},
     {"name": "Circle Alliance Bank", "url": "https://api.cdr.circle.com.au/cds-au/v1"},

--- a/public/datasources.json
+++ b/public/datasources.json
@@ -15,7 +15,7 @@
     {"name": "bcu", "url": "https://ob-api.bcu.com.au/cds-au/v1", "icon": "https://www.bcu.com.au/content-publishers/logo/BCU_Logo_CMYK_200px.png"},
     {"name": "BDCU Alliance Bank", "url": "https://api.cdr.bdcualliancebank.com.au/cds-au/v1"},
     {"name": "Bendigo Bank", "url": "https://api.cdr.bendigobank.com.au/cds-au/v1"},
-    {"name": "Beyond Bank", "url": "https://public.cdr.api.beyondbank.com.au/cds-au/v1"},
+    {"name": "Beyond Bank Australia", "url": "https://public.cdr.api.beyondbank.com.au/cds-au/v1", "icon": "https://beyondbank.com.au/dam/document-repository/mpos/Beyond-Logo-RGB.png"},
     {"name": "BOQ", "url": "https://secure.api.boq.com.au/cds-au/v1", "icon": "https://www.boq.com.au/content/dam/boq/images/blog-images/BOQ_png_notagline_stk.png"},
     {"name": "BOQ Specialist", "url": "https://secure.api.boqspecialist.com.au/cds-au/v1", "icon": "https://www.boqspecialist.com.au/content/dam/boqs/images/logo.png"},
     {"name": "Circle Alliance Bank", "url": "https://api.cdr.circle.com.au/cds-au/v1"},


### PR DESCRIPTION
Raised on behalf of Beyond Bank from the information provided in email.

*Beyond Bank*, please check the correctness of the entry. For instance, if you you want the _name_ to read, say, _Beyond Bank Australia_ or anything else, please let us know. Also, we didn't have the _icon_ (logo) URL, so if you want to provide that as well, please also let us know. Alternatively, you can fork this repo, add the amendments as a new commit to your _feature/beyond-bank-ds_ branch and raise a new Pull Request.

If you respond here, please also email us at cdr-data61@csiro.au to verify the association of your GitHub persona with the bank.

More information can be found here: https://cdr-support.zendesk.com/hc/en-us/articles/900002933263-Add-your-organisation-to-the-Banking-Product-Comparator-tool

Please be aware that currently your endpoints do not support CORS, so won't work in the Comparator.