### PR TITLE
Bank of Sydney data source

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -11,6 +11,7 @@
     {"name": "AWA Alliance Bank", "url": "https://api.cdr.awaalliancebank.com.au/cds-au/v1"},
     {"name": "Bank Australia", "url": "https://cds.api.bankaust.com.au/cds-au/v1", "icon": "https://www.bankaust.com.au/globalassets/assets/imagery/logos/bank-australia/ba-horizontal-logo.png"},
     {"name": "Bank of China Australia", "url": "https://obdevp.bank-of-china.net.au/cds-au/v1", "icon": "https://www.bankofchina.com/images/boc2013_ovs_logo.png"},
+    {"name": "Bank of Sydney", "url": "https://openbank.api.banksyd.com.au/cds-au/v1", "icon": "https://www.banksyd.com.au/globalassets/images/logos/bos-logo-edge-fix.svg"},
     {"name": "BankVic", "url": "https://ib.bankvic.com.au/openbanking/cds-au/v1", "icon": "https://www.datocms-assets.com/28619/1591331902-bv-x5f-logo-x5f-master-x5f-vert-x5f-cmyk.svg"},
     {"name": "Bankwest", "url": "https://open-api.bankwest.com.au/bwpublic/cds-au/v1", "icon": "https://www.bankwest.com.au/content/dam/bankwest/web-assets/images/global/logo/logo-bankwest-horizontal-charcoal.png"},
     {"name": "bcu", "url": "https://ob-api.bcu.com.au/cds-au/v1", "icon": "https://www.bcu.com.au/content-publishers/logo/BCU_Logo_CMYK_200px.png"},


### PR DESCRIPTION
Created on behalf of Bank of Sydney from the email request:


Hi Team,
 
We have been trying to add Bank of Sydney endpoints to the Product Comparator tool, however, we haven’t been able to do so. Please may we request the below to be added?
 
{
"name": "Bank of Sydney",                         
"url": "https://openbank.api.banksyd.com.au/cds-au/v1",                         
"icon": "https://www.banksyd.com.au/globalassets/images/logos/bos-logo-edge-fix.svg"    
} 
 
Thank you,