### PR TITLE
Fix for comparison of prod with null fee

### DIFF
--- a/src/components/comparison/ComparisonPanel.js
+++ b/src/components/comparison/ComparisonPanel.js
@@ -109,7 +109,7 @@ const render = (product, key) => {
     case 'fees':
       return !!product[key] && product[key].length > 0 &&
         <ul style={{margin: 0, padding:0}}>
-          {product[key].sort((a, b)=>ecomp(a.name, b.name)).map((fee, index) => <Fee key={index} fee={fee}/>)}
+          {product[key].filter(fee => fee).sort((a, b)=>ecomp(a.name, b.name)).map((fee, index) => <Fee key={index} fee={fee}/>)}
         </ul>
     case 'cardArt':
       return !!product[key] && product[key].length > 0 &&


### PR DESCRIPTION
This is a fix for comparison of products with buggy details containing null elements in the array of fees.