### PR TITLE
Update URL of GMCU

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -44,7 +44,7 @@
     {"name": "Gateway Bank", "url": "https://public.cdr-api.gatewaybank.com.au"},
     {"name": "Geelong Bank", "url": "https://online.geelongbank.com.au/OpenBanking", "icon": "https://geelongbank.com.au/media/2007/geelongbank_logotag_horizontal.png"},
     {"name": "Goldfields Money", "url": "https://prd.bnk.com.au", "icon": "https://d26ocd7o1oup8r.cloudfront.net/2020/09/BNK-Online-Banking-Logo-300920.png"},
-    {"name": "Goulburn Murray Credit Union", "url": "https://gmcu.cds.cuscal.com.au"},
+    {"name": "Goulburn Murray Credit Union", "url": "https://secure.gmcu.com.au/openbanking"},
     {"name": "Greater Bank", "url": "https://public.cdr-api.greater.com.au", "icon": "https://www.greater.com.au/media/2356486/greaterbank_openbanking_logo.png"},
     {"name": "Heritage Bank", "url": "https://product.api.heritage.com.au"},
     {"name": "Horizon Bank", "url": "https://onlinebanking.horizonbank.com.au/openbanking"},


### PR DESCRIPTION
Actioning from email:
```
. . .
We have changed our software supplier and urgently need to update our endpoint to:
https://secure.gmcu.com.au/openbanking/cds-au/v1/banking/products

Can you please help us amend our endpoint?
 
Regards,
Brett
```
The base URL for datasources.json is derived.