### PR TITLE
Create The Capricornian Ltd endpoint update

### DIFF
--- a/The Capricornian Ltd endpoint update
+++ b/The Capricornian Ltd endpoint update
@@ -1,0 +1,2 @@
+{"name": "The Capricornian Ltd", "url":  "https://onlinebanking.capricornian.com.au/OpenBanking/"},
+{"name": "The Capricornian Ltd", "url":  "https://public.cdr.onlinebanking.capricornian.com.au", "icon": "https://www.capricornian.com.au/wp-content/themes/capricornian/images/capricornian-logo.png"


### PR DESCRIPTION
Update The Capricornian Ltd URL to new endpoint.

Endpoint is changing from;
https://onlinebanking.capricornian.com.au/OpenBanking/

to 

https://public.cdr.onlinebanking.capricornian.com.au

Maintaining the same icon URL, https://www.capricornian.com.au/wp-content/themes/capricornian/images/capricornian-logo.png

Regards,

Shane