### PR TITLE
Updated Newcastle Permanent Public Base URI to the new endpoint.

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -63,7 +63,7 @@
     {"name": "MyLife MyFinance", "url": "https://openbanking-api.mylifemyfinance.com.au"},
     {"name": "MOVE Bank", "url": "https://api.movebank.com.au/OpenBanking", "icon": "https://movebank.com.au/media/3405/move-bank-logo-website.png"},
     {"name": "MyState Bank", "url": "https://openbank.api.mystate.com.au", "icon": "https://mystate.com.au/wp-content/uploads/MyState_Logo_s.png"},
-    {"name": "Newcastle Permanent Building Society", "url": "https://api.newcastlepermanent.com.au", "icon": "https://www.newcastlepermanent.com.au/-/media/images/houselogo.png"},
+    {"name": "Newcastle Permanent Building Society", "url": "https://openbank.newcastlepermanent.com.au", "icon": "https://www.newcastlepermanent.com.au/-/media/images/houselogo.png"},
     {"name": "Northern Inland Credit Union", "url": "https://api.cds.nicu.com.au", "icon": "https://asset.nicu.com.au/images/NICU_logo.png"},
     {"name": "Nova Alliance Bank", "url": "https://api.cdr.novaalliancebank.com.au"},
     {"name": "Orange Credit Union Limited", "url": "https://online.orangecu.com.au/openbanking"},


### PR DESCRIPTION
Updated Newcastle Permanent Public Base URI to the new endpoint.
Old URI
https://api.newcastlepermanent.com.au/
New URI
https://openbank.newcastlepermanent.com.au/